### PR TITLE
feat: 갤러리 기능 구현

### DIFF
--- a/src/pages/GalleryPage/ReviewItem.tsx
+++ b/src/pages/GalleryPage/ReviewItem.tsx
@@ -1,0 +1,88 @@
+import styled from '@emotion/styled'
+import LazyImageComponent3 from '../LazyImagePage/LazyImage3/LazyComponent3'
+import { Image } from './Reviews'
+import { useCallback } from 'react'
+import { SetGalleryData } from '.'
+
+interface ReviewItemProps {
+  id: string
+  number: number
+  name: string
+  text: string
+  images?: Image[]
+  setGalleryData: SetGalleryData
+}
+
+const ReviewItem = ({
+  id,
+  name,
+  text,
+  images = [],
+  setGalleryData
+}: ReviewItemProps) => {
+  const imageLength = images.length
+
+  const openGallery = useCallback(() => {
+    setGalleryData({
+      galleryKey: id,
+      images,
+      initialIndex: 0
+    })
+  }, [id, images, setGalleryData])
+
+  return (
+    <ReviewItemLi>
+      <NameStyle>🗨️{name}</NameStyle>
+      {imageLength > 0 && (
+        <ReviewImage onClick={openGallery}>
+          <LazyImageComponent3
+            src={images[0].thumbnail}
+            width={150}
+            height={80}
+          />
+          {imageLength > 1 && (
+            <ImageCountSpan>+{imageLength - 1}</ImageCountSpan>
+          )}
+        </ReviewImage>
+      )}
+      <TextStyle>{text}</TextStyle>
+    </ReviewItemLi>
+  )
+}
+
+export default ReviewItem
+
+const ReviewItemLi = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid lightgray;
+`
+const NameStyle = styled.p`
+  font-size: 16px;
+  font-weight: 700;
+`
+const TextStyle = styled.p`
+  font-size: 15px;
+  font-weight: 800;
+  color: gray;
+`
+
+const ReviewImage = styled.div`
+  position: relative;
+  display: inline-block;
+  width: 150px;
+  border-radius: 10px;
+  overflow: hidden;
+`
+const ImageCountSpan = styled.span`
+  position: absolute;
+  bottom: 10px;
+  right: 5px;
+  background-color: rgba(0, 0, 0, 0.7);
+  font-size: 10px;
+  color: white;
+  padding: 3px;
+  border-radius: 5px;
+`

--- a/src/pages/GalleryPage/Reviews.tsx
+++ b/src/pages/GalleryPage/Reviews.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useMemo } from 'react'
+import ScrollBox from '../HorizontalScrollBoxPage/HorizontalScrollBox2/ScrollBoxComponent2'
+import data from './data'
+import LazyImageComponent3 from '../LazyImagePage/LazyImage3/LazyComponent3'
+import ReviewItem from './ReviewItem'
+import styled from '@emotion/styled'
+import { SetGalleryData } from '.'
+
+export type Image = { id: string; thumbnail: string; fullsize: string }
+
+const totalImages: Image[] = data.flatMap(d => d.images || [])
+
+const Reviews = ({ setGalleryData }: { setGalleryData: SetGalleryData }) => {
+  const list = useMemo(() => totalImages.slice(0, 10), [])
+
+  const handleTotalItemClick = useCallback(
+    (_: unknown, i: number) => () => {
+      setGalleryData({
+        galleryKey: 'total',
+        images: totalImages,
+        initialIndex: i
+      })
+    },
+    [setGalleryData]
+  )
+
+  return (
+    <div>
+      <h2>⭐후기⭐</h2>
+      <Container>
+        <article>
+          <h3>📷사진 모아보기</h3>
+          <ScrollBox isSetScrollBar={true}>
+            {list.map((item, index) => (
+              <ScrollBox.Wrapper
+                key={item.id}
+                index={index}>
+                <div onClick={handleTotalItemClick(item, index)}>
+                  <LazyImageComponent3
+                    src={item.thumbnail}
+                    width={160}
+                    height={80}
+                  />
+                </div>
+              </ScrollBox.Wrapper>
+            ))}
+          </ScrollBox>
+        </article>
+
+        <article>
+          <h3>✍️리뷰</h3>
+          <ReviewItemUl>
+            {data.map(item => (
+              <ReviewItem
+                setGalleryData={setGalleryData}
+                {...item}
+                key={item.id}
+              />
+            ))}
+          </ReviewItemUl>
+        </article>
+      </Container>
+    </div>
+  )
+}
+
+export default Reviews
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 50px;
+  padding: 10px 30px;
+`
+
+const ReviewItemUl = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin: 15px;
+`

--- a/src/pages/GalleryPage/data.ts
+++ b/src/pages/GalleryPage/data.ts
@@ -1,0 +1,400 @@
+const data = [
+  {
+    id: '659510c0734732abaea6238a',
+    number: 1,
+    name: '이민수',
+    text: '이 제품을 사용해보니 정말 만족스러웠습니다. 매우 유용하고 품질이 뛰어나요.',
+    images: [
+      {
+        id: '10',
+        thumbnail: 'https://loremflickr.com/150/80?lock=10',
+        fullsize: 'https://loremflickr.com/600/320?lock=10'
+      },
+      {
+        id: '11',
+        thumbnail: 'https://loremflickr.com/150/80?lock=11',
+        fullsize: 'https://loremflickr.com/600/320?lock=11'
+      },
+      {
+        id: '12',
+        thumbnail: 'https://loremflickr.com/150/80?lock=12',
+        fullsize: 'https://loremflickr.com/600/320?lock=12'
+      }
+    ]
+  },
+  {
+    id: '659510c0a6b228fca2e24fe0',
+    number: 2,
+    name: '김지현',
+    text: '배송이 빨라서 좋았고, 제품도 기대 이상으로 훌륭했습니다. 강력 추천합니다!',
+    images: [
+      {
+        id: '20',
+        thumbnail: 'https://loremflickr.com/150/80?lock=20',
+        fullsize: 'https://loremflickr.com/600/320?lock=20'
+      },
+      {
+        id: '21',
+        thumbnail: 'https://loremflickr.com/150/80?lock=21',
+        fullsize: 'https://loremflickr.com/600/320?lock=21'
+      },
+      {
+        id: '22',
+        thumbnail: 'https://loremflickr.com/150/80?lock=22',
+        fullsize: 'https://loremflickr.com/600/320?lock=22'
+      },
+      {
+        id: '23',
+        thumbnail: 'https://loremflickr.com/150/80?lock=23',
+        fullsize: 'https://loremflickr.com/600/320?lock=23'
+      }
+    ]
+  },
+  {
+    id: '659510c0d7178ebedab3c59c',
+    number: 3,
+    name: '박상민',
+    text: '제품이 기대보다 훨씬 좋습니다. 다시 구매할 의향이 있습니다.'
+  },
+  {
+    id: '659510c0770255a077390a36',
+    number: 4,
+    name: '최은지',
+    text: '아주 만족스러운 구매였습니다. 품질이 뛰어나고 가격도 합리적입니다.',
+    images: [
+      {
+        id: '40',
+        thumbnail: 'https://loremflickr.com/150/80?lock=40',
+        fullsize: 'https://loremflickr.com/600/320?lock=40'
+      },
+      {
+        id: '41',
+        thumbnail: 'https://loremflickr.com/150/80?lock=41',
+        fullsize: 'https://loremflickr.com/600/320?lock=41'
+      }
+    ]
+  },
+  {
+    id: '659510c0a5a2d578844593e6',
+    number: 5,
+    name: '이서연',
+    text: '정말 좋은 제품입니다! 사용하기 쉽고 효과도 확실히 느껴집니다.',
+    images: [
+      {
+        id: '50',
+        thumbnail: 'https://loremflickr.com/150/80?lock=50',
+        fullsize: 'https://loremflickr.com/600/320?lock=50'
+      },
+      {
+        id: '51',
+        thumbnail: 'https://loremflickr.com/150/80?lock=51',
+        fullsize: 'https://loremflickr.com/600/320?lock=51'
+      }
+    ]
+  },
+  {
+    id: '659510c0f843ca89c89f295f',
+    number: 6,
+    name: '홍길동',
+    text: '만족스러운 제품이었습니다. 다음에도 다시 구매할게요.',
+    images: [
+      {
+        id: '60',
+        thumbnail: 'https://loremflickr.com/150/80?lock=60',
+        fullsize: 'https://loremflickr.com/600/320?lock=60'
+      }
+    ]
+  },
+  {
+    id: '659510c04831c0836eb47959',
+    number: 7,
+    name: '장윤아',
+    text: '제품의 품질이 정말 좋습니다. 강추합니다!',
+    images: [
+      {
+        id: '70',
+        thumbnail: 'https://loremflickr.com/150/80?lock=70',
+        fullsize: 'https://loremflickr.com/600/320?lock=70'
+      },
+      {
+        id: '71',
+        thumbnail: 'https://loremflickr.com/150/80?lock=71',
+        fullsize: 'https://loremflickr.com/600/320?lock=71'
+      }
+    ]
+  },
+  {
+    id: '659510c064e521cd6745b491',
+    number: 8,
+    name: '김태희',
+    text: '이 제품 정말 최고입니다! 다른 제품은 고려하지 않게 되네요.',
+    images: [
+      {
+        id: '80',
+        thumbnail: 'https://loremflickr.com/150/80?lock=80',
+        fullsize: 'https://loremflickr.com/600/320?lock=80'
+      },
+      {
+        id: '81',
+        thumbnail: 'https://loremflickr.com/150/80?lock=81',
+        fullsize: 'https://loremflickr.com/600/320?lock=81'
+      },
+      {
+        id: '82',
+        thumbnail: 'https://loremflickr.com/150/80?lock=82',
+        fullsize: 'https://loremflickr.com/600/320?lock=82'
+      },
+      {
+        id: '83',
+        thumbnail: 'https://loremflickr.com/150/80?lock=83',
+        fullsize: 'https://loremflickr.com/600/320?lock=83'
+      },
+      {
+        id: '84',
+        thumbnail: 'https://loremflickr.com/150/80?lock=84',
+        fullsize: 'https://loremflickr.com/600/320?lock=84'
+      }
+    ]
+  },
+  {
+    id: '659510c0458f93e629581c2b',
+    number: 9,
+    name: '오민재',
+    text: '배송도 빠르고 품질도 좋아서 매우 만족합니다.'
+  },
+  {
+    id: '659510c01e3d058c0fb39098',
+    number: 10,
+    name: '정하늘',
+    text: '이 제품은 진짜 추천할 만합니다. 사용해보세요!',
+    images: [
+      {
+        id: '100',
+        thumbnail: 'https://loremflickr.com/150/80?lock=100',
+        fullsize: 'https://loremflickr.com/600/320?lock=100'
+      },
+      {
+        id: '101',
+        thumbnail: 'https://loremflickr.com/150/80?lock=101',
+        fullsize: 'https://loremflickr.com/600/320?lock=101'
+      },
+      {
+        id: '102',
+        thumbnail: 'https://loremflickr.com/150/80?lock=102',
+        fullsize: 'https://loremflickr.com/600/320?lock=102'
+      }
+    ]
+  },
+  {
+    id: '659510c07d0f0295df7fa094',
+    number: 11,
+    name: '이수민',
+    text: '정말 유용한 제품이에요. 앞으로 자주 사용할 것 같습니다.',
+    images: [
+      {
+        id: '110',
+        thumbnail: 'https://loremflickr.com/150/80?lock=110',
+        fullsize: 'https://loremflickr.com/600/320?lock=110'
+      },
+      {
+        id: '111',
+        thumbnail: 'https://loremflickr.com/150/80?lock=111',
+        fullsize: 'https://loremflickr.com/600/320?lock=111'
+      }
+    ]
+  },
+  {
+    id: '659510c05ecf9c08eb76b29e',
+    number: 12,
+    name: '박민지',
+    text: '이 제품을 사용해보니 기대 이상입니다. 구매하길 잘했어요!',
+    images: [
+      {
+        id: '120',
+        thumbnail: 'https://loremflickr.com/150/80?lock=120',
+        fullsize: 'https://loremflickr.com/600/320?lock=120'
+      },
+      {
+        id: '121',
+        thumbnail: 'https://loremflickr.com/150/80?lock=121',
+        fullsize: 'https://loremflickr.com/600/320?lock=121'
+      },
+      {
+        id: '122',
+        thumbnail: 'https://loremflickr.com/150/80?lock=122',
+        fullsize: 'https://loremflickr.com/600/320?lock=122'
+      },
+      {
+        id: '123',
+        thumbnail: 'https://loremflickr.com/150/80?lock=123',
+        fullsize: 'https://loremflickr.com/600/320?lock=123'
+      }
+    ]
+  },
+  {
+    id: '659510c0ac1cc94a8eca97dd',
+    number: 13,
+    name: '김지훈',
+    text: '이 제품은 품질이 뛰어나고 사용하기도 편리합니다. 다음에 또 구매할게요!',
+    images: [
+      {
+        id: '130',
+        thumbnail: 'https://loremflickr.com/150/80?lock=130',
+        fullsize: 'https://loremflickr.com/600/320?lock=130'
+      }
+    ]
+  },
+  {
+    id: '659510c007866db6904d6816',
+    number: 14,
+    name: '이영희',
+    text: '정말 마음에 드는 제품입니다. 친구에게도 추천할 예정입니다.',
+    images: [
+      {
+        id: '140',
+        thumbnail: 'https://loremflickr.com/150/80?lock=140',
+        fullsize: 'https://loremflickr.com/600/320?lock=140'
+      },
+      {
+        id: '141',
+        thumbnail: 'https://loremflickr.com/150/80?lock=141',
+        fullsize: 'https://loremflickr.com/600/320?lock=141'
+      },
+      {
+        id: '142',
+        thumbnail: 'https://loremflickr.com/150/80?lock=142',
+        fullsize: 'https://loremflickr.com/600/320?lock=142'
+      }
+    ]
+  },
+  {
+    id: '659510c0cb382c7649f77677',
+    number: 15,
+    name: '정재훈',
+    text: '이 제품은 정말 대단합니다. 품질이 뛰어나고 사용하기도 간편해요.',
+    images: [
+      {
+        id: '150',
+        thumbnail: 'https://loremflickr.com/150/80?lock=150',
+        fullsize: 'https://loremflickr.com/600/320?lock=150'
+      },
+      {
+        id: '151',
+        thumbnail: 'https://loremflickr.com/150/80?lock=151',
+        fullsize: 'https://loremflickr.com/600/320?lock=151'
+      },
+      {
+        id: '152',
+        thumbnail: 'https://loremflickr.com/150/80?lock=152',
+        fullsize: 'https://loremflickr.com/600/320?lock=152'
+      },
+      {
+        id: '153',
+        thumbnail: 'https://loremflickr.com/150/80?lock=153',
+        fullsize: 'https://loremflickr.com/600/320?lock=153'
+      }
+    ]
+  },
+  {
+    id: '659510c0373fe1c34fdab2bb',
+    number: 16,
+    name: '배수진',
+    text: '배송이 정말 빨라서 놀랐습니다. 제품도 기대 이상이에요.',
+    images: [
+      {
+        id: '160',
+        thumbnail: 'https://loremflickr.com/150/80?lock=160',
+        fullsize: 'https://loremflickr.com/600/320?lock=160'
+      },
+      {
+        id: '161',
+        thumbnail: 'https://loremflickr.com/150/80?lock=161',
+        fullsize: 'https://loremflickr.com/600/320?lock=161'
+      }
+    ]
+  },
+  {
+    id: '659510c080f4e2db0308c801',
+    number: 17,
+    name: '한지민',
+    text: '이 제품은 정말 훌륭합니다. 사용해보니 강력 추천합니다!',
+    images: [
+      {
+        id: '170',
+        thumbnail: 'https://loremflickr.com/150/80?lock=170',
+        fullsize: 'https://loremflickr.com/600/320?lock=170'
+      },
+      {
+        id: '171',
+        thumbnail: 'https://loremflickr.com/150/80?lock=171',
+        fullsize: 'https://loremflickr.com/600/320?lock=171'
+      },
+      {
+        id: '172',
+        thumbnail: 'https://loremflickr.com/150/80?lock=172',
+        fullsize: 'https://loremflickr.com/600/320?lock=172'
+      },
+      {
+        id: '173',
+        thumbnail: 'https://loremflickr.com/150/80?lock=173',
+        fullsize: 'https://loremflickr.com/600/320?lock=173'
+      }
+    ]
+  },
+  {
+    id: '659510c0fe22b1b65fc732ec',
+    number: 18,
+    name: '김유정',
+    text: '정말 훌륭한 제품입니다. 품질이 너무 좋아서 만족합니다.',
+    images: [
+      {
+        id: '180',
+        thumbnail: 'https://loremflickr.com/150/80?lock=180',
+        fullsize: 'https://loremflickr.com/600/320?lock=180'
+      },
+      {
+        id: '181',
+        thumbnail: 'https://loremflickr.com/150/80?lock=181',
+        fullsize: 'https://loremflickr.com/600/320?lock=181'
+      }
+    ]
+  },
+  {
+    id: '659510c04860901522987376',
+    number: 19,
+    name: '이상혁',
+    text: '이 제품을 사용해보니 너무 좋습니다. 다음에도 꼭 구매할게요.',
+    images: [
+      {
+        id: '190',
+        thumbnail: 'https://loremflickr.com/150/80?lock=190',
+        fullsize: 'https://loremflickr.com/600/320?lock=190'
+      }
+    ]
+  },
+  {
+    id: '659510c0f72e3b7014d1fa18',
+    number: 20,
+    name: '홍서연',
+    text: '정말 만족스러운 제품입니다. 강력히 추천합니다!',
+    images: [
+      {
+        id: '200',
+        thumbnail: 'https://loremflickr.com/150/80?lock=200',
+        fullsize: 'https://loremflickr.com/600/320?lock=200'
+      },
+      {
+        id: '201',
+        thumbnail: 'https://loremflickr.com/150/80?lock=201',
+        fullsize: 'https://loremflickr.com/600/320?lock=201'
+      },
+      {
+        id: '202',
+        thumbnail: 'https://loremflickr.com/150/80?lock=202',
+        fullsize: 'https://loremflickr.com/600/320?lock=202'
+      }
+    ]
+  }
+]
+
+export default data

--- a/src/pages/GalleryPage/index.tsx
+++ b/src/pages/GalleryPage/index.tsx
@@ -88,7 +88,7 @@ const GalleryModal = ({
         <Modal.Content>
           <ModalContent>
             <ModalContentMainView>
-              <img
+              <LazyImageComponent3
                 src={fullSizeImageUrl}
                 width={600}
                 height={320}

--- a/src/pages/GalleryPage/index.tsx
+++ b/src/pages/GalleryPage/index.tsx
@@ -1,0 +1,154 @@
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react'
+import Reviews, { Image } from './Reviews'
+import useDialogModal from '../ModalPage/Modal4/useDialogModal'
+import Modal from '../ModalPage/Modal4/Modal'
+import { ScrollBoxHandle } from '../HorizontalScrollBoxPage/HorizontalScrollBox1/ScrollBoxComponent'
+import LazyImageComponent3 from '../LazyImagePage/LazyImage3/LazyComponent3'
+import ScrollBox from '../HorizontalScrollBoxPage/HorizontalScrollBox2/ScrollBoxComponent2'
+import styled from '@emotion/styled'
+
+export type GalleryProps = {
+  galleryKey: string
+  images: Image[]
+  initialIndex: number
+}
+export type SetGalleryData = Dispatch<SetStateAction<GalleryProps>>
+
+type Zoom = 'scaleUp' | 'scaleDown'
+
+const initialGalleryProps: GalleryProps = {
+  galleryKey: '',
+  images: [],
+  initialIndex: 0
+}
+
+const GalleryPage = () => {
+  const [galleryData, setGalleryData] =
+    useState<GalleryProps>(initialGalleryProps)
+  return (
+    <div>
+      <h2>Gallery #1</h2>
+      <Reviews setGalleryData={setGalleryData} />
+      <GalleryModal
+        key={galleryData.galleryKey}
+        {...galleryData}
+        setGalleryData={setGalleryData}
+      />
+    </div>
+  )
+}
+
+export default GalleryPage
+
+const GalleryModal = ({
+  images,
+  initialIndex = 0,
+  setGalleryData
+}: {
+  images: Image[]
+  initialIndex: number
+  setGalleryData: SetGalleryData
+}) => {
+  const { modalRef, openModal, closeModal } = useDialogModal()
+  const scrollBoxRef = useRef<ScrollBoxHandle>()
+  const [currentIndex, setCurrentIndex] = useState(initialIndex)
+  const [zoom, setZoom] = useState(1)
+
+  const onClose = () => {
+    setGalleryData(initialGalleryProps)
+    closeModal()
+  }
+
+  const handleItemClick = (item: unknown, index: number) => () => {
+    setCurrentIndex(index)
+    setZoom(1)
+    scrollBoxRef.current!.scrollFocus(index, 'smooth')
+  }
+
+  const handleZoom = (zoom: Zoom) => {
+    setZoom(prev =>
+      Math.min(Math.max(prev + (zoom === 'scaleUp' ? 1 : -1) * 0.25, 0.5), 2)
+    )
+  }
+  const resetZoom = () => setZoom(1)
+
+  useEffect(() => {
+    if (images.length) openModal()
+  }, [images, openModal])
+
+  const fullSizeImageUrl = images[currentIndex]?.fullsize || ''
+
+  return (
+    <Modal
+      modalRef={modalRef}
+      hide={onClose}
+      hideOnClickOutside>
+      <ModalContainer>
+        <Modal.Header hide={onClose} />
+        <Modal.Content>
+          <ModalContent>
+            <ModalContentMainView>
+              <img
+                src={fullSizeImageUrl}
+                width={600}
+                height={320}
+                key={fullSizeImageUrl}
+                style={{ transform: `scale(${zoom})` }}
+              />
+              <ZoomButtonContainer>
+                <button onClick={() => handleZoom('scaleDown')}>-</button>
+                <button onClick={resetZoom}>{Math.round(zoom * 100)}%</button>
+                <button onClick={() => handleZoom('scaleUp')}>+</button>
+              </ZoomButtonContainer>
+            </ModalContentMainView>
+            <ScrollBox
+              isSetScrollBar={true}
+              ref={scrollBoxRef}>
+              {images.map((item, index) => (
+                <ScrollBox.Wrapper
+                  key={item.id}
+                  index={index}>
+                  <div onClick={handleItemClick(item, index)}>
+                    <LazyImageComponent3
+                      src={item.thumbnail}
+                      width={160}
+                      height={80}
+                    />
+                  </div>
+                </ScrollBox.Wrapper>
+              ))}
+            </ScrollBox>
+          </ModalContent>
+        </Modal.Content>
+      </ModalContainer>
+    </Modal>
+  )
+}
+
+const ModalContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.85);
+`
+
+const ModalContent = styled.div`
+  display: flex;
+  height: 90%;
+  flex-direction: column;
+`
+
+const ModalContentMainView = styled.div`
+  position: relative;
+  flex-grow: 1;
+  margin-bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`
+
+const ZoomButtonContainer = styled.div`
+  position: absolute;
+  bottom: 0;
+  right: 0;
+`

--- a/src/pages/GalleryPage/index.tsx
+++ b/src/pages/GalleryPage/index.tsx
@@ -59,7 +59,7 @@ const GalleryModal = ({
     closeModal()
   }
 
-  const handleItemClick = (item: unknown, index: number) => () => {
+  const handleItemClick = (_item: unknown, index: number) => () => {
     setCurrentIndex(index)
     setZoom(1)
     scrollBoxRef.current!.scrollFocus(index, 'smooth')

--- a/src/pages/LazyImagePage/LazyImage3/LazyComponent3.tsx
+++ b/src/pages/LazyImagePage/LazyImage3/LazyComponent3.tsx
@@ -11,7 +11,8 @@ const LazyImageComponent3 = ({
   src,
   width = 600,
   height = 320,
-  alt = '이미지'
+  alt = '이미지',
+  ...props
 }: LazyImageComponentProps) => {
   const imgRef = useRef<HTMLImageElement>(null)
   const [loaded, setLoaded] = useState(false)
@@ -47,6 +48,7 @@ const LazyImageComponent3 = ({
       height={height}
       onLoad={onLoad}
       alt={alt}
+      {...props}
     />
   )
 }

--- a/src/pages/LazyImagePage/LazyImage3/LazyImage2.styled.ts
+++ b/src/pages/LazyImagePage/LazyImage3/LazyImage2.styled.ts
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import { ImageContentProps } from '../LazyImage1/LazyImage1.styled'
 
 export const ImageContent3 = styled.img<ImageContentProps>`
+  position: relative;
   filter: ${({ load }) => (load ? 'blur(0)' : 'blur(15px)')};
   transition: filter 0.7s;
 `

--- a/src/pages/ModalPage/Modal1/Modal1.styled.ts
+++ b/src/pages/ModalPage/Modal1/Modal1.styled.ts
@@ -84,6 +84,7 @@ export const CloseButton = styled.button`
 
 export const ModalContentContainer = styled.div`
   padding: 20px;
+  height: 100%;
 `
 
 export const ModalFooterContainer = styled.div`

--- a/src/pages/ModalPage/Modal3/Modal.tsx
+++ b/src/pages/ModalPage/Modal3/Modal.tsx
@@ -59,7 +59,7 @@ const Modal = ({ isOpen, close, children }: ModalProps) => {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        close()
+        setIsAnimating(false)
       }
     }
 
@@ -67,7 +67,7 @@ const Modal = ({ isOpen, close, children }: ModalProps) => {
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [close])
+  }, [])
 
   return isOpen
     ? createPortal(

--- a/src/pages/ModalPage/Modal3/Modal3.styled.ts
+++ b/src/pages/ModalPage/Modal3/Modal3.styled.ts
@@ -65,14 +65,6 @@ export const ModalContent = styled.div<ModalContentProps>`
   flex-direction: column;
   overflow: hidden;
   position: absolute;
-  box-sizing: border-box;
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1);
-  border: 1px solid #242424;
-  border-radius: 6px;
-  background-color: #fff;
-  max-height: calc(100vh - 80px);
-  max-width: calc(100vw - 80px);
-  min-width: 70%;
 
   overflow-y: auto;
   -ms-overflow-style: auto;

--- a/src/pages/ModalPage/Modal3/index.tsx
+++ b/src/pages/ModalPage/Modal3/index.tsx
@@ -3,6 +3,7 @@ import useModal from './useModal'
 import Modal from './Modal'
 import { PlaceHolderDiv } from '../Modal1'
 import UiExplanation from '@/components/UiExplanation'
+import styled from '@emotion/styled'
 
 const Modal3 = () => {
   return (
@@ -51,6 +52,14 @@ const Modal3 = () => {
           - ex.모달이 닫히면서 useState의 상태가 변화하면 애니메이션이
           동작하지않습니다.
         </p>
+        <p>
+          - Modal.Header나 내부 취소 버튼 같은 경우 close() 메서드로 Modal이
+          닫히기 때문에 애니메이션이 동작하지 않습니다.
+        </p>
+        <p>
+          - setIsAnimating으로 상태가 변화되어야 애니메이션이 동작하고 Modal이
+          사라집니다.
+        </p>
       </UiExplanation>
       <PlaceHolderDiv />
     </div>
@@ -78,22 +87,34 @@ export const ConfirmModal = ({
     <Modal
       isOpen={isOpen}
       close={close}>
-      <Modal.Header
-        title={'ConfirmModal'}
-        hide={close}
-      />
-      <Modal.Content>{children}</Modal.Content>
-      <p>
-        현재 확인 유무:
-        {confirmed ? '✅' : '❌'}
-      </p>
-      <Modal.Footer>
-        <button onClick={onConfirm}>확인</button>
-        <button onClick={onCancel}>취소</button>
-      </Modal.Footer>
+      <ModalContentStyled>
+        <Modal.Header
+          title={'ConfirmModal'}
+          hide={close}
+        />
+        <Modal.Content>{children}</Modal.Content>
+        <p>
+          현재 확인 유무:
+          {confirmed ? '✅' : '❌'}
+        </p>
+        <Modal.Footer>
+          <button onClick={onConfirm}>확인</button>
+          <button onClick={onCancel}>취소</button>
+        </Modal.Footer>
+      </ModalContentStyled>
     </Modal>
   )
 }
+
+const ModalContentStyled = styled.div`
+  box-sizing: border-box;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1);
+  border: 1px solid #242424;
+  border-radius: 6px;
+  background-color: #fff;
+  height: calc(100vh - 500px);
+  width: calc(100vw - 500px);
+`
 
 const ConfirmTrigger = ({ children }: { children: ReactNode }) => {
   const { open, close, isOpen } = useModal()

--- a/src/pages/ModalPage/Modal4/Modal4.styled.ts
+++ b/src/pages/ModalPage/Modal4/Modal4.styled.ts
@@ -22,18 +22,15 @@ const popOut = keyframes`
 
 export const StyledDialog = styled.dialog`
   display: block;
+  width: 100%;
+  height: 100%;
   inset: 0;
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1);
-  max-height: calc(100vh - 80px);
-  max-width: calc(100vw - 80px);
-  min-width: 250px;
-  border: 1px solid #242424;
-  border-radius: 6px;
-  background-color: #fff;
   padding: 0;
+  border: 0;
   overflow: hidden;
   transition: opacity 0.5s;
   animation: ${popOut} 0.3s ease forwards;
+  background-color: transparent;
 
   &::backdrop {
     backdrop-filter: blur(2px);

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -55,6 +55,7 @@ import ImageSlide3 from '@/pages/ImageSlidePage/ImageSlide3'
 import Carousel1 from '@/pages/CarouselPage/Carousel1'
 import Carousel2 from '@/pages/CarouselPage/Carousel2'
 import ImageSlide4 from '@/pages/ImageSlidePage/ImageSlide4'
+import GalleryPage from '@/pages/GalleryPage'
 
 export const router = createBrowserRouter([
   {
@@ -272,6 +273,10 @@ export const router = createBrowserRouter([
       {
         path: '/carousel/2_r',
         element: <Carousel2 />
+      },
+      {
+        path: '/gallery',
+        element: <GalleryPage />
       }
     ]
   }
@@ -344,7 +349,8 @@ export const routePaths = [
   '/carousel',
   '/carousel/1_r',
   '/carousel/2_r',
-  '/image-slide/4_r'
+  '/image-slide/4_r',
+  '/gallery'
 ] as const
 export type ROUTE_PATH = (typeof routePaths)[number]
 
@@ -381,7 +387,8 @@ export const routes: Record<ROUTE_PATH, ROUTE> = {
       '/modal',
       '/popover',
       '/image-slide',
-      '/carousel'
+      '/carousel',
+      '/gallery'
     ]
   },
   '/accordion': {
@@ -824,6 +831,12 @@ export const routes: Record<ROUTE_PATH, ROUTE> = {
     link: '/carousel/2_r',
     name: '캐로셀 두 번째 방법',
     children: Carousel2
+  },
+  '/gallery': {
+    key: '/gallery',
+    link: '/gallery',
+    name: '13. 갤러리',
+    children: GalleryPage
   }
 }
 


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - close #number -->

- close #35 

## ✅ 작업 내용

### 1.  기본적으로 구성되는 갤러리 페이지 구현
![image](https://github.com/user-attachments/assets/cc16bb95-afba-4a46-bea6-4f01b602f921)
- 모든 사진을 볼 수 있는 `사진 모아보기` 섹션
- 각 사진 마다 리뷰를 볼 수 있는 `후기` 섹션
- 각 이미지를 클릭하면 해당 사진을 확대할 수 있는 기능
- `사진 모아보기` 섹션의 이미지를 클릭 시 모든 사진이 하단 부분에 `횡스크롤 박스`로 나열되는 기능
- `후기` 섹션의 사진을 클릭 시 각 리뷰에 해당되는 사진들만 하단 부분에 `횡 스크롤 박스`로 나열되는 기능
- `LazyImage` 기능 사용

### 2. 사진 상세 보기 기능
![image](https://github.com/user-attachments/assets/7ba625b3-86cf-47b6-b2bc-8b1ff287c4ee)
- 사진 확대, 축소 기능
- 관련된 사진들 하단에 나열 및 선택 기능


## ♾️ 기타

- 기존에 만들었던 컴포넌트를 조합해서 기능을 구현했습니다.